### PR TITLE
Made fs2hcp T2 compatible, added in hcp preprocessing scripts

### DIFF
--- a/bin/filter_hcp.sh
+++ b/bin/filter_hcp.sh
@@ -7,6 +7,7 @@
 
 if [ ! $# -eq 2 ]
 then
+  echo "Creates an eroded white matter mask and eroded ventricle mask for a subject"
   echo "Usage: "
   echo "      $(basename $0) <MNINonLinear> <output_path>"
   echo "Arguments:"

--- a/bin/filter_hcp.sh
+++ b/bin/filter_hcp.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+# SESS should point to the MNINonLinear folder for a subject
+# Expected inputs:
+#   In MNINonLinear folder: aparc+aseg.nii.gz and brainmask_fs.nii.gz
+
+SESS=$1
+OUT=$2
+
+mask=brainmask_fs.nii.gz
+
+# eroded white matter mask
+if [ ! -f ${OUT}/anat_wm_ero.nii.gz ]; then
+    # Grab the relevant segments
+    wb_command \
+        -volume-math "x == 2 || \
+                      x == 7 || \
+                      x == 41 || \
+                      x == 46 || \
+                      x == 251 || \
+                      x == 252 || \
+                      x == 253 || \
+                      x == 254 || \
+                      x == 255" \
+        ${OUT}/anat_wm.nii.gz \
+        -var x ${SESS}/aparc+aseg.nii.gz > /dev/null 2>&1
+
+    # Erode the mask a little bit
+    wb_command -volume-erode \
+        ${OUT}/anat_wm.nii.gz 0.5 \
+        ${OUT}/anat_wm_ero.nii.gz
+
+    # Zero any voxels in anat_wm_ero that dont overlap with brainmask_fs
+    wb_command -volume-math \
+        "a*b" ${OUT}/anat_wm_ero.nii.gz \
+        -var a ${OUT}/anat_wm_ero.nii.gz \
+        -var b ${SESS}/${mask} > /dev/null 2>&1
+fi
+
+# eroded ventricle mask
+if [ ! -f ${OUT}/anat_vent_ero.nii.gz ]; then
+    wb_command \
+        -volume-math "x == 4 || \
+                      x == 43" \
+        ${OUT}/anat_vent.nii.gz \
+        -var x ${SESS}/aparc+aseg.nii.gz > /dev/null 2>&1
+
+    wb_command \
+        -volume-math "x == 10 || \
+                      x == 11 || \
+                      x == 26 || \
+                      x == 49 || \
+                      x == 50 || \
+                      x == 58" \
+        ${OUT}/anat_tmp_nonvent.nii.gz \
+        -var x ${SESS}/aparc+aseg.nii.gz > /dev/null 2>&1
+
+    wb_command -volume-dilate \
+        ${OUT}/anat_tmp_nonvent.nii.gz 0.5 NEAREST \
+        ${OUT}/anat_tmp_nonvent_dia.nii.gz
+
+    wb_command \
+        -volume-math "a - a*b*c" \
+        ${OUT}/anat_vent_ero.nii.gz \
+        -var a ${OUT}/anat_vent.nii.gz \
+        -var b ${OUT}/anat_tmp_nonvent_dia.nii.gz \
+        -var c ${SESS}/${mask} > /dev/null 2>&1
+fi

--- a/bin/filter_hcp.sh
+++ b/bin/filter_hcp.sh
@@ -1,8 +1,20 @@
 #!/bin/bash
 
+# Makes an eroded white matter mask and an eroded ventricle mask.
 # SESS should point to the MNINonLinear folder for a subject
 # Expected inputs:
 #   In MNINonLinear folder: aparc+aseg.nii.gz and brainmask_fs.nii.gz
+
+if [ ! $# -eq 2 ]
+then
+  echo "Usage: "
+  echo "      $(basename $0) <MNINonLinear> <output_path>"
+  echo "Arguments:"
+  echo "      <MNINonLinear>      The full path to one subject's MNINonLinear"
+  echo "                          folder (from the HCP pipeline outputs)."
+  echo "      <output_path>       Full path to the location to deposit all outputs"
+  exit 1
+fi
 
 SESS=$1
 OUT=$2

--- a/bin/fs2hcp.py
+++ b/bin/fs2hcp.py
@@ -53,11 +53,11 @@ class Settings(HCPSettings):
         # reg_name hard coded for now, option later? (MSMSulc)
         self.reg_name = "FS"
         self.resample = arguments['--resample-LowRestoNative']
-        self.use_T2s = arguments['--T2']
         self.fs_root_dir = self.__set_fs_subjects_dir(arguments)
         self.subject = self.__get_subject(arguments)
         self.FSL_dir = self.__set_FSL_dir()
         self.ciftify_data_dir = self.__get_ciftify_data()
+        self.use_T2 = self.__get_T2(arguments, self.subject)
 
         # Read settings from yaml
         self.__config = self.__read_settings(arguments['--settings-yaml'])
@@ -173,6 +173,14 @@ class Settings(HCPSettings):
                 sys.exit(1)
             resolution_config[key] = reg_item
         return resolution_config
+
+    def __get_T2(self, arguments, subject):
+        if not arguments['--T2']:
+            return None
+        raw_T2 = os.path.join(subject.fs_folder, 'mri/orig/T2raw.mgz')
+        if not os.path.exists(raw_T2):
+            return None
+        return raw_T2
 
 class Subject(object):
     def __init__(self, hcp_dir, fs_root_dir, subject_id):
@@ -1233,7 +1241,7 @@ def convert_FS_surfaces_to_gifti(subject_id, freesurfer_subject_dir, meshes,
             add_to_spec=False)
 
 def convert_inputs_to_MNI_space(reg_settings, hcp_templates, temp_dir,
-        use_T2=False):
+        use_T2=None):
     logger.info(section_header("Registering T1wImage to MNI template using FSL "
             "FNIRT"))
     run_T1_FNIRT_registration(reg_settings, temp_dir)
@@ -1269,7 +1277,7 @@ def resample_freesurfer_mgz(T1w_nii, freesurfer_mgz, image_nii):
             image_nii])
 
 def convert_T1_and_freesurfer_inputs(T1w_nii, subject, hcp_templates,
-        use_T2=False):
+        T2_raw=None):
     logger.info(section_header("Converting T1wImage and Segmentations from "
             "freesurfer"))
     ###### convert the mgz T1w and put in T1w folder
@@ -1278,10 +1286,9 @@ def convert_T1_and_freesurfer_inputs(T1w_nii, subject, hcp_templates,
     for image in ['wmparc', 'aparc.a2009s+aseg', 'aparc+aseg']:
       convert_freesurfer_mgz(image, T1w_nii, hcp_templates, subject.fs_folder,
             subject.T1w_dir)
-    if use_T2:
-        fs_T2 = os.path.join(subject.fs_folder, 'mri/orig/T2raw.mgz')
+    if T2_raw:
         T2w_nii = os.path.join(subject.T1w_dir, 'T2w.nii.gz')
-        resample_freesurfer_mgz(T1w_nii, fs_T2, T2w_nii)
+        resample_freesurfer_mgz(T1w_nii, T2_raw, T2w_nii)
 
 def create_output_directories(meshes, xfms_dir, rois_dir, results_dir):
     for mesh in meshes.values():
@@ -1318,15 +1325,15 @@ def main(temp_dir, settings):
     T1w_nii = os.path.join(subject.T1w_dir, settings.registration['T1wImage'])
     wmparc = os.path.join(subject.T1w_dir, 'wmparc.nii.gz')
     convert_T1_and_freesurfer_inputs(T1w_nii, subject,
-            settings.ciftify_data_dir, use_T2=settings.use_T2s)
+            settings.ciftify_data_dir, T2_raw=settings.use_T2)
     prepare_T1_image(wmparc, T1w_nii, settings.registration)
 
     convert_inputs_to_MNI_space(settings.registration, settings.ciftify_data_dir,
-            temp_dir, use_T2=settings.use_T2s)
+            temp_dir, use_T2=settings.use_T2)
 
     #Create Spec Files including the T1w files
     add_anat_images_to_spec_files(meshes, subject.id)
-    if settings.use_T2s:
+    if settings.use_T2:
         add_anat_images_to_spec_files(meshes, subject.id, img_type='T2wImage')
 
     # Import Subcortical ROIs and resample to the Grayordinate Resolution
@@ -1407,6 +1414,9 @@ if __name__ == '__main__':
     fh = settings.subject.get_subject_log_handler(formatter)
     logger.addHandler(fh)
 
+    if arguments['--T2'] and not settings.use_T2:
+        logger.error("Cannot locate T2 for {} in freesurfer "
+                "outputs".format(settings.subject.id))
 
     logger.info(section_header("Starting fs2hcp"))
     with ciftify.utilities.TempDir() as tmpdir:

--- a/bin/fs2hcp.py
+++ b/bin/fs2hcp.py
@@ -15,6 +15,7 @@ Options:
                               (overides the SUBJECTS_DIR environment variable)
   --resample-LowRestoNative   Resample the 32k Meshes to Native Space (creates
                               additional output files)
+  --T2                        Include T2 files from freesurfer outputs
   --settings-yaml PATH        Path to a yaml configuration file. Overrides
                               the default settings in
                               ciftify/data/fs2hcp_settings.yaml
@@ -51,7 +52,8 @@ class Settings(HCPSettings):
         HCPSettings.__init__(self, arguments)
         # reg_name hard coded for now, option later? (MSMSulc)
         self.reg_name = "FS"
-        self.resample = arguments["--resample-LowRestoNative"]
+        self.resample = arguments['--resample-LowRestoNative']
+        self.use_T2s = arguments['--T2']
         self.fs_root_dir = self.__set_fs_subjects_dir(arguments)
         self.subject = self.__get_subject(arguments)
         self.FSL_dir = self.__set_FSL_dir()
@@ -254,19 +256,22 @@ def define_meshes(subject_hcp, high_res_mesh, low_res_meshes, temp_dir,
             'meshname': 'native',
             'tmpdir': os.path.join(temp_dir, 'native'),
             'T1wImage': os.path.join(subject_hcp, 'T1w', 'T1w.nii.gz'),
+            'T2wImage': os.path.join(subject_hcp, 'T1w', 'T2w.nii.gz'),
             'DenseMapsFolder': os.path.join(subject_hcp, 'MNINonLinear', 'Native')},
         'AtlasSpaceNative':{
             'Folder' : os.path.join(subject_hcp, 'MNINonLinear', 'Native'),
             'ROI': 'roi',
             'meshname': 'native',
             'tmpdir': os.path.join(temp_dir, 'native'),
-            'T1wImage': os.path.join(subject_hcp, 'MNINonLinear', 'T1w.nii.gz')},
+            'T1wImage': os.path.join(subject_hcp, 'MNINonLinear', 'T1w.nii.gz'),
+            'T2wImage': os.path.join(subject_hcp, 'MNINonLinear', 'T2w.nii.gz')},
         'HighResMesh':{
             'Folder' : os.path.join(subject_hcp, 'MNINonLinear'),
             'ROI': 'atlasroi',
             'meshname': '{}k_fs_LR'.format(high_res_mesh),
             'tmpdir': os.path.join(temp_dir, '{}k_fs_LR'.format(high_res_mesh)),
-            'T1wImage': os.path.join(subject_hcp, 'MNINonLinear', 'T1w.nii.gz')}
+            'T1wImage': os.path.join(subject_hcp, 'MNINonLinear', 'T1w.nii.gz'),
+            'T2wImage': os.path.join(subject_hcp, 'MNINonLinear', 'T2w.nii.gz')}
     }
     for low_res_mesh in low_res_meshes:
         meshes['{}k_fs_LR'.format(low_res_mesh)] = {
@@ -275,7 +280,8 @@ def define_meshes(subject_hcp, high_res_mesh, low_res_meshes, temp_dir,
             'ROI' : 'atlasroi',
             'meshname': '{}k_fs_LR'.format(low_res_mesh),
             'tmpdir': os.path.join(temp_dir, '{}k_fs_LR'.format(low_res_mesh)),
-            'T1wImage': os.path.join(subject_hcp, 'MNINonLinear', 'T1w.nii.gz')}
+            'T1wImage': os.path.join(subject_hcp, 'MNINonLinear', 'T1w.nii.gz'),
+            'T2wImage': os.path.join(subject_hcp, 'MNINonLinear', 'T2w.nii.gz')}
         if make_low_res:
              meshes['Native{}k_fs_LR'.format(low_res_mesh)] = {
                  'Folder': os.path.join(subject_hcp, 'T1w',
@@ -285,6 +291,7 @@ def define_meshes(subject_hcp, high_res_mesh, low_res_meshes, temp_dir,
                  'tmpdir': os.path.join(temp_dir,
                         '{}k_fs_LR'.format(low_res_mesh)),
                  'T1wImage': os.path.join(subject_hcp, 'T1w', 'T1w.nii.gz'),
+                 'T2wImage': os.path.join(subject_hcp, 'T1w', 'T2w.nii.gz'),
                  'DenseMapsFolder': os.path.join(subject_hcp, 'MNINonLinear',
                         'fsaverage_LR{}k'.format(low_res_mesh))}
     return meshes
@@ -474,12 +481,12 @@ def add_dense_maps_to_spec_file(subject_id, mesh_settings, dscalar_types):
         run(['wb_command', '-add-to-spec-file', os.path.realpath(spec_file(
                 subject_id, mesh_settings)), 'INVALID', dlabel_file])
 
-def add_T1w_images_to_spec_files(meshes, subject_id):
+def add_anat_images_to_spec_files(meshes, subject_id, img_type='T1wImage'):
     '''add all the T1wImages to their associated spec_files'''
     for mesh in meshes.values():
          run(['wb_command', '-add-to-spec-file',
               os.path.realpath(spec_file(subject_id, mesh)),
-              'INVALID', os.path.realpath(mesh['T1wImage'])])
+              'INVALID', os.path.realpath(mesh[img_type])])
 
 def write_cras_file(freesurfer_folder, cras_mat):
     '''read info about the surface affine matrix from freesurfer output and
@@ -721,8 +728,7 @@ def convert_freesurfer_mgz(image_name,  T1w_nii, hcp_templates,
         logger.error("{} not found, exiting.".format(freesurfer_mgz))
         sys.exit(1)
     image_nii = os.path.join(out_dir, '{}.nii.gz'.format(image_name))
-    run(['mri_convert', '-rt', 'nearest', '-rl', T1w_nii, freesurfer_mgz,
-            image_nii])
+    resample_freesurfer_mgz(T1w_nii, freesurfer_mgz, image_nii)
     run(['wb_command', '-logging', 'SEVERE','-volume-label-import', image_nii,
             os.path.join(hcp_templates, 'hcp_config', 'FreeSurferAllLut.txt'),
             image_nii, '-drop-unused-labels'])
@@ -1226,7 +1232,8 @@ def convert_FS_surfaces_to_gifti(subject_id, freesurfer_subject_dir, meshes,
             freesurfer_subject_dir, meshes['AtlasSpaceNative'],
             add_to_spec=False)
 
-def convert_inputs_to_MNI_space(reg_settings, hcp_templates, temp_dir):
+def convert_inputs_to_MNI_space(reg_settings, hcp_templates, temp_dir,
+        use_T2=False):
     logger.info(section_header("Registering T1wImage to MNI template using FSL "
             "FNIRT"))
     run_T1_FNIRT_registration(reg_settings, temp_dir)
@@ -1240,6 +1247,11 @@ def convert_inputs_to_MNI_space(reg_settings, hcp_templates, temp_dir):
     apply_nonlinear_warp_to_nifti_rois('brainmask_fs', reg_settings,
             hcp_templates, import_labels=False)
 
+    if use_T2:
+        # Transform T2 to MNI space too
+        apply_nonlinear_warp_to_nifti_rois('T2w', reg_settings, hcp_templates,
+                import_labels=False)
+
 def prepare_T1_image(wmparc, T1w_nii, reg_settings):
     T1w_brain_mask = os.path.join(reg_settings['src_dir'],
             reg_settings['BrainMask'])
@@ -1252,7 +1264,12 @@ def prepare_T1_image(wmparc, T1w_nii, reg_settings):
     ## apply brain mask to the T1wImage
     mask_T1w_image(T1w_nii, T1w_brain_mask, T1w_brain_nii)
 
-def convert_T1_and_freesurfer_inputs(T1w_nii, subject, hcp_templates):
+def resample_freesurfer_mgz(T1w_nii, freesurfer_mgz, image_nii):
+    run(['mri_convert', '-rt', 'nearest', '-rl', T1w_nii, freesurfer_mgz,
+            image_nii])
+
+def convert_T1_and_freesurfer_inputs(T1w_nii, subject, hcp_templates,
+        use_T2=False):
     logger.info(section_header("Converting T1wImage and Segmentations from "
             "freesurfer"))
     ###### convert the mgz T1w and put in T1w folder
@@ -1261,6 +1278,10 @@ def convert_T1_and_freesurfer_inputs(T1w_nii, subject, hcp_templates):
     for image in ['wmparc', 'aparc.a2009s+aseg', 'aparc+aseg']:
       convert_freesurfer_mgz(image, T1w_nii, hcp_templates, subject.fs_folder,
             subject.T1w_dir)
+    if use_T2:
+        fs_T2 = os.path.join(subject.fs_folder, 'mri/orig/T2raw.mgz')
+        T2w_nii = os.path.join(subject.T1w_dir, 'T2w.nii.gz')
+        resample_freesurfer_mgz(T1w_nii, fs_T2, T2w_nii)
 
 def create_output_directories(meshes, xfms_dir, rois_dir, results_dir):
     for mesh in meshes.values():
@@ -1297,14 +1318,16 @@ def main(temp_dir, settings):
     T1w_nii = os.path.join(subject.T1w_dir, settings.registration['T1wImage'])
     wmparc = os.path.join(subject.T1w_dir, 'wmparc.nii.gz')
     convert_T1_and_freesurfer_inputs(T1w_nii, subject,
-            settings.ciftify_data_dir)
+            settings.ciftify_data_dir, use_T2=settings.use_T2s)
     prepare_T1_image(wmparc, T1w_nii, settings.registration)
 
     convert_inputs_to_MNI_space(settings.registration, settings.ciftify_data_dir,
-            temp_dir)
+            temp_dir, use_T2=settings.use_T2s)
 
     #Create Spec Files including the T1w files
-    add_T1w_images_to_spec_files(meshes, subject.id)
+    add_anat_images_to_spec_files(meshes, subject.id)
+    if settings.use_T2s:
+        add_anat_images_to_spec_files(meshes, subject.id, img_type='T2wImage')
 
     # Import Subcortical ROIs and resample to the Grayordinate Resolution
     create_cifti_subcortical_ROIs(subject.atlas_space_dir, settings.hcp_dir,

--- a/bin/hcp_preprocessing.py
+++ b/bin/hcp_preprocessing.py
@@ -1,0 +1,200 @@
+#!/usr/bin/env python
+"""
+Tries to match the preprocessing described in "Functional connectome
+fingerprinting: identifying individuals using patterns of brain connectivity".
+
+i.e. generates an eroded white matter mask, eroded CSF mask, and calculates
+mean time courses in the white matter and CSF. May also calulate the global
+signal.
+
+Usage:
+    hcp_preprocessing.py [options] <input_dir> <rest_file>...
+
+Arguments:
+    <input_dir>                 Full path to the MNINonLinear folder of a
+                                subject's hcp outputs.
+
+    <rest_file>                 The full path to a rest image to generate
+                                the mean time courses + global signal for.
+                                Can be repeated if multiple files must be
+                                processed
+
+Options:
+    --output_dir PATH           Sets a path for all outputs (if unset, outputs
+                                will be left in the directory of the results
+                                file they were generated for)
+"""
+import os
+import sys
+import tempfile
+import shutil
+import subprocess
+
+from docopt import docopt
+
+def main(temp):
+    arguments = docopt(__doc__)
+    input_dir = arguments['<input_dir>']
+    rest_files = arguments['<rest_file>']
+    user_output_dir = arguments['--output_dir']
+
+    verify_wb_available()
+    verify_FSL_available()
+    verify_ciftify_available()
+
+    if user_output_dir and os.listdir(user_output_dir):
+        return
+
+    brainmask = get_brainmask(input_dir)
+    wm_mask, csf_mask = generate_masks(input_dir, temp)
+
+    for image in rest_files:
+        if not os.path.exists(image):
+            print("Rest file {} does not exist. Skipping".format(image))
+            continue
+
+        resampled_wm = resample_mask(image, wm_mask, temp)
+        resampled_csf = resample_mask(image, csf_mask, temp)
+        resampled_brainmask = resample_mask(image, brainmask, temp)
+
+        image_name = get_image_name(image)
+        output_path = get_output_path(user_output_dir, image)
+
+        wm_csv = os.path.join(output_path, image_name + '_WM.csv')
+        csf_csv = os.path.join(output_path, image_name + '_CSF.csv')
+        global_signal_csv = os.path.join(output_path, image_name + '_GS.csv')
+
+        ciftify_meants(image, resampled_wm, wm_csv, mask=resampled_brainmask)
+        ciftify_meants(image, resampled_csf, csf_csv, mask=resampled_brainmask)
+        ciftify_meants(image, resampled_brainmask, global_signal_csv)
+
+def get_brainmask(input_dir):
+    brainmask = os.path.join(input_dir, 'brainmask_fs.nii.gz')
+    if not os.path.exists(brainmask):
+        sys.exit("{} does not exist".format(brainmask))
+    return brainmask
+
+def generate_masks(input_path, output_path):
+    run_filter(input_path, output_path)
+
+    wm_mask = os.path.join(output_path, "anat_wm_ero.nii.gz")
+    csf_mask = os.path.join(output_path, "anat_vent_ero.nii.gz")
+    if not os.path.exists(wm_mask) or not os.path.exists(csf_mask):
+        sys.exit("filter_hcp.sh has failed to generate the white matter mask "
+                "or the csf mask for inputs in {}".format(input_path))
+
+    return wm_mask, csf_mask
+
+def run_filter(input_path, output):
+    run_filter = "filter_hcp.sh {} {}".format(input_path, output)
+    rtn = subprocess.call(run_filter, shell=True)
+    if rtn:
+        sys.exit("filter_hcp.sh experienced an error while generating "
+                "masks for {}".format(input_path))
+
+def get_output_path(user_path, image):
+    if user_path:
+        return user_path
+    return os.path.dirname(image)
+
+def resample_mask(rest_image, mask, output_path):
+    vol_dims = get_nifti_dimensions(rest_image)
+    mask_dims = get_nifti_dimensions(mask)
+
+    if mask_dims == vol_dims:
+        return mask
+
+    new_mask = os.path.join(output_path, 'resampled_' + os.path.basename(mask))
+    if os.path.exists(new_mask):
+        prev_resample_dims = get_nifti_dimensions(new_mask)
+        if prev_resample_dims == vol_dims:
+            return new_mask
+        # Remove old resampled mask if it doesnt match the dims of current image
+        os.remove(new_mask)
+
+    resample = "flirt -in {} -ref {} -out {} -applyxfm".format(mask, rest_image,
+            new_mask)
+    subprocess.call(resample, shell=True)
+
+    binarize = "fslmaths {} -thr 0.5 -bin {}".format(new_mask, new_mask)
+    subprocess.call(binarize, shell=True)
+
+    if not os.path.exists(new_mask):
+        sys.exit("Failed to resample {} to size {}".format(mask, vol_dims))
+    return new_mask
+
+def get_nifti_dimensions(nii_path):
+    fields = get_fslinfo_fields(nii_path)
+
+    pixdims = filter(lambda x: 'pixdim' in x, fields)
+    dims = {}
+    for dim in pixdims:
+        key, val = dim.split()
+        dims[key] = val
+
+    x = dims['pixdim1']
+    y = dims['pixdim2']
+    z = dims['pixdim3']
+
+    return x, y, z
+
+def get_fslinfo_fields(nii_path):
+    fsl_info = "fslinfo {}".format(nii_path)
+    nii_info = subprocess.check_output(fsl_info, shell=True)
+    fields = nii_info.strip().split('\n')
+    return fields
+
+def get_image_name(image):
+    image_bn = os.path.basename(image)
+    return image_bn.replace('.nii', '').replace('.gz', '')
+
+def ciftify_meants(image, seed, csv, mask=None):
+    meants = "ciftify_meants {} {} --outputcsv {}".format(image, seed, csv)
+    if mask:
+        meants = meants + ' --mask {}'.format(mask)
+    rtn = subprocess.check_output(meants, shell=True)
+
+    if rtn or not os.path.exists(csv):
+        sys.exit("Error experienced while generating {}".format(csv))
+
+def verify_wb_available():
+    """ Raise SystemExit if connectome workbench is not installed """
+    which_wb = "which wb_command"
+    try:
+        subprocess.check_output(which_wb, shell=True)
+    except subprocess.CalledProcessError:
+        raise SystemExit("wb_command not found. Please check that Connectome "
+                "Workbench is installed.")
+
+def verify_FSL_available():
+    """ Raise SystemExit if FSL is not installed. """
+    which_FSL = "which fslinfo"
+    try:
+        subprocess.check_output(which_FSL, shell=True)
+    except subprocess.CalledProcessError:
+        raise SystemExit("fslinfo not found. Please check that FSL is installed.")
+
+def verify_ciftify_available():
+    which = "which ciftify_meants"
+    try:
+        subprocess.check_output(which, shell=True)
+    except subprocess.CalledProcessError:
+        raise SystemExit("ciftify_meants not found. Please check that Ciftify "
+                "is installed.")
+
+class TempDir(object):
+    def __init__(self):
+        self.path = None
+        return
+
+    def __enter__(self):
+        self.path = tempfile.mkdtemp()
+        return self.path
+
+    def __exit__(self, type, value, traceback):
+        if self.path is not None:
+            shutil.rmtree(self.path)
+
+if __name__ == "__main__":
+    with TempDir() as temp:
+        main(temp)


### PR DESCRIPTION
fs2hcp will now use the T2 file if the --T2 flag is set and if the file is present in the subject's freesurfer outputs.

hcp_preprocessing.py and its support script filter_hcp.sh have been added.
