### PR TITLE
Fixed test_utils.py and updated the patch for one test

### DIFF
--- a/tests/test_ciftify_recon_all.py
+++ b/tests/test_ciftify_recon_all.py
@@ -210,19 +210,19 @@ class TestSettings(unittest.TestCase):
                               'xfms_dir' : 'MNINonLinear/xfms'},
             'FSL_fnirt' : {'2mm' : {'FNIRTConfig' : 'etc/flirtsch/T1_2_MNI152_2mm.cnf'}}}
 
-    @patch('ciftify.utils.WorkFlowSettings.__read_settings')
+    @patch('ciftify.bin.ciftify_recon_all.WorkFlowSettings', spec=True)
     @patch('os.path.exists')
     @patch('ciftify.config.find_fsl')
     @patch('ciftify.config.find_ciftify_global')
     def test_fs_root_dir_set_to_user_value_when_given(self, mock_ciftify,
-            mock_fsl, mock_exists, mock_yaml_settings):
+                mock_fsl, mock_exists, mock_settings):
         # This is to avoid test failure if shell environment changes
         mock_ciftify.return_value = '/somepath/ciftify/data'
         mock_fsl.return_value = '/somepath/FSL'
         # This is to avoid sys.exit calls due to the mock directories not
         # existing.
         mock_exists.return_value = True
-        mock_yaml_settings.return_value = self.yaml_config
+        mock_settings._WorkFlowSettings__read_settings.return_value = self.yaml_config
 
         settings = ciftify_recon_all.Settings(self.arguments)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,12 +27,9 @@ class TestGetSubj(unittest.TestCase):
         # Set up mocks
         mock_exists.return_value = True
         walk = (self.path, all_subjects, [])
-        mock_walk.return_value.next.return_value = walk
-        print(next(os.walk(self.path))[1])
+        mock_walk.return_value.__next__.return_value = walk
 
         subjects = list(utilities.get_subj(self.path))
-        print(subjects)
-        print(all_subjects)
 
         # Subjects must be wrapped in list call because py3 returns a generator
         assert sorted(list(subjects)) == sorted(all_subjects)
@@ -49,9 +46,9 @@ class TestGetSubj(unittest.TestCase):
         # Pretend the path exists, but is empty dir
         mock_exists.return_value = True
         walk = (self.path, [], [])
-        mock_walk.return_value.next.return_value = walk
+        mock_walk.return_value.__next__.return_value = walk
 
-        subjects = utilities.get_subj(self.path)
+        subjects = list(utilities.get_subj(self.path))
 
         assert subjects == []
 
@@ -61,7 +58,7 @@ class TestGetSubj(unittest.TestCase):
             mock_exists):
         mock_exists.return_value = True
         walk = (self.path, ['subject1', '.git', 'subject2', '.hidden2'], [])
-        mock_walk.return_value.next.return_value = walk
+        mock_walk.return_value.__next__.return_value = walk
 
         subjects = utilities.get_subj(self.path)
 
@@ -80,11 +77,13 @@ class TestGetSubj(unittest.TestCase):
         # Set up mocks
         mock_exists.return_value = True
         walk = (self.path, all_subjects, [])
-        mock_walk.return_value.next.return_value = walk
+        mock_walk.return_value.__next__.return_value = walk
 
-        subjects = utilities.get_subj(self.path, user_filter='CMH')
+        subjects = list(utilities.get_subj(self.path, user_filter='CMH'))
 
-        assert sorted(list(subjects)) == sorted(tagged_subjects)
+        assert len(subjects) == len(tagged_subjects)
+        for item in tagged_subjects:
+            assert item in subjects
 
 class TestMakeDir(unittest.TestCase):
     path = '/some/path/somewhere'
@@ -136,7 +135,7 @@ class TestRun(unittest.TestCase):
 
     @patch('subprocess.Popen')
     def test_dry_run_prevents_command_from_running(self, mock_popen):
-        mock_popen.return_value.communicate.return_value = ('', '')
+        mock_popen.return_value.communicate.return_value = (b'', b'')
         mock_popen.return_value.returncode = 0
 
         utilities.run('touch ./test_file.txt', dryrun=True)
@@ -145,7 +144,7 @@ class TestRun(unittest.TestCase):
 
     @patch('subprocess.Popen')
     def test_handles_string_commands(self, mock_popen):
-        mock_popen.return_value.communicate.return_value = ('', '')
+        mock_popen.return_value.communicate.return_value = (b'', b'')
         mock_popen.return_value.returncode = 0
         cmd = 'touch ./test_file.txt'
 
@@ -158,7 +157,7 @@ class TestRun(unittest.TestCase):
 
     @patch('subprocess.Popen')
     def test_handles_list_commands(self, mock_popen):
-        mock_popen.return_value.communicate.return_value = ('', '')
+        mock_popen.return_value.communicate.return_value = (b'', b'')
         mock_popen.return_value.returncode = 0
         cmd = ['touch', './test_file.txt']
 


### PR DESCRIPTION
The test_utils.py (formerly test_utilities.py) test cases now work. The one modified test case inside test_ciftify_recon_all DOES NOT work, but the patch is now correct. That test is failing now because of the MSM feature you added contains a bug (or two)! If msm is not found `config.find_msm()` tries to call .replace on 'None'. Also `config.verify_msm_available()` tries to call sys.exit() but config.py hasn't imported sys.