### PR TITLE
Updates to address small bugs with seedcorr

### DIFF
--- a/ciftify/bin/ciftify_clean_img.py
+++ b/ciftify/bin/ciftify_clean_img.py
@@ -124,7 +124,7 @@ class UserSettings(object):
         for args_cols_list in [self.cf_cols, self.cf_sq_cols, self.cf_sq_cols, self.cf_sqtd_cols]:
             for colname_arg in args_cols_list:
                 if colname_arg not in confounddf.columns:
-                    logger.error('Indicated colBIDS_ZHH/sub-10186/ses-02/func/sub-10186_ses-02_task-rest_bold.nii.gzumn {} not in confounds'.format(colname_arg))
+                    logger.error('Indicated column {} not in confounds'.format(colname_arg))
                     sys.exit(1)
         return confounddf
 
@@ -317,6 +317,7 @@ def mangle_confounds(settings):
     for colname in settings.cf_sqtd_cols:
         x = df.loc[:,colname].diff().fillna(0)
         outdf.loc[:,'{}_sqlag'.format(colname)] = x**2
+    outdf = outdf.fillna(0) # added at the request of Colin
     return outdf
 
 def clean_image_with_nilearn(input_img, confound_signals, settings):

--- a/ciftify/bin/ciftify_seed_corr.py
+++ b/ciftify/bin/ciftify_seed_corr.py
@@ -185,10 +185,8 @@ def run_ciftify_seed_corr(settings, tempdir):
     # get mean seed timeseries
     ## even if no mask given, mask out all zero elements..
     std_array = np.std(func_data, axis=1)
-    m_array = np.mean(func_data, axis=1)
     std_nonzero = np.where(std_array > 0)[0]
-    m_nonzero = np.where(m_array != 0)[0]
-    idx_mask = np.intersect1d(std_nonzero, m_nonzero)
+    idx_mask = std_nonzero
     if settings.mask:
         idx_of_mask = np.where(mask_data > 0)[0]
         idx_mask = np.intersect1d(idx_mask, idx_of_mask)
@@ -227,13 +225,12 @@ def run_ciftify_seed_corr(settings, tempdir):
             '-var', 'x', nifti_corr_output])
 
     if settings.func.type == "cifti":
-        run(['wb_command', '-cifti-reduce', settings.func.path, 'MIN', os.path.join(tempdir, 'template.dscalar.nii')])
-
         ## convert back
         run(['wb_command','-cifti-convert','-from-nifti',
             nifti_Zcorr_output,
-            os.path.join(tempdir, 'template.dscalar.nii'),
-            '{}.dscalar.nii'.format(settings.output_prefix)])
+            settings.func.path,
+            '{}.dscalar.nii'.format(settings.output_prefix),
+            '-reset-scalars'])
 
 
 if __name__ == '__main__':

--- a/ciftify/bin/ciftify_surface_rois.py
+++ b/ciftify/bin/ciftify_surface_rois.py
@@ -85,6 +85,7 @@ def run_ciftify_surface_rois(arguments, tmpdir):
         df = pd.read_csv(inputcsv)
     except:
         logger.critical("Could not load csv {}".format(inputcsv))
+        sys.exit(1)
 
     ## check that vertex-col and hemi-col exist
     if vertex_col not in df.columns:


### PR DESCRIPTION
+ seedcorr does not exclude voxels where mean is 0 (only where sd is 0)
+ this is also true for cifti_vis_PINT
+ fixed typo in error message of ciftify_clean_img
+ also makes ciftify clean image force na to zero in covariates