### PR TITLE
[ENH] add read xfm option to ciftify_recon_all

### DIFF
--- a/ciftify/bin/ciftify_recon_all.py
+++ b/ciftify/bin/ciftify_recon_all.py
@@ -101,7 +101,7 @@ def run_ciftify_recon_all(temp_dir, settings):
     subject = settings.subject
 
     log_inputs(settings.fs_root_dir, settings.work_dir, subject.id,
-            settings.msm_config)
+            settings.registration, settings.msm_config)
     log_build_environment(settings)
 
     fs_version = pars_recon_all_logs(subject.fs_folder)
@@ -449,13 +449,17 @@ class Subject(object):
 
 
 ############ Step 0: Settings and Logging #############################
-def log_inputs(fs_dir, work_dir, subject_id, msm_config=None):
+def log_inputs(fs_dir, work_dir, subject_id, registration_config, msm_config=None):
     logger.info("Arguments: ")
     logger.info('    freesurfer SUBJECTS_DIR: {}'.format(fs_dir))
     logger.info('    CIFTIFY_WORKDIR directory: {}'.format(work_dir))
     logger.info('    Subject: {}'.format(subject_id))
     if msm_config:
         logger.info('    MSM config file: {}'.format(msm_config))
+    if registration_config['User_AtlasTransform_NonLinear']:
+        logger.info('User given transforms (to be copied to MNINonLinear/xfm):')
+        logger.info('     User given linear tranform: {}'.format(registration_config['User_AtlasTransform_Linear']))
+        logger.info('     User given non-linear tranform: {}'.format(registration_config['User_AtlasTransform_NonLinear']))
 
 def log_build_environment(settings):
     '''print the running environment info to the logs (info)'''
@@ -664,8 +668,8 @@ def run_T1_FNIRT_registration(reg_settings, temp_dir):
     T1w2_standard_linear = os.path.join(temp_dir,
             'T1w2StandardLinearImage.nii.gz')
     if User_AtlasTransform_Linear:
-        run(['cp', User_AtlasTransform_Linear, AtlasTransform_Linear])
-        run(['cp', User_AtlasTransform_NonLinear, AtlasTransform_NonLinear])
+        run(['cp', User_AtlasTransform_Linear, os.path.join(xfms_dir,AtlasTransform_Linear)])
+        run(['cp', User_AtlasTransform_NonLinear, os.path.join(xfms_dir,AtlasTransform_NonLinear)])
     else:
         run(['flirt', '-interp', 'spline', '-dof', '12',
             '-in', os.path.join(src_dir, T1wBrain), '-ref', standard_T1wBrain,

--- a/ciftify/bin/ciftify_recon_all.py
+++ b/ciftify/bin/ciftify_recon_all.py
@@ -390,8 +390,8 @@ class Settings(WorkFlowSettings):
             registration_config[key] = os.path.join(self.subject.path, subfolders)
         resolution_config = WorkFlowSettings.get_resolution_config(self, method, standard_res)
         registration_config.update(resolution_config)
-        if any(read_nonlin_xfm, read_lin_xfm):
-            if all(read_nonlin_xfm, read_lin_xfm):
+        if any([read_nonlin_xfm, read_lin_xfm]):
+            if all([read_nonlin_xfm, read_lin_xfm]):
                 ciftify.utils.check_input_readable(read_nonlin_xfm)
                 registration_config['User_AtlasTransform_NonLinear'] = read_nonlin_xfm
                 ciftify.utils.check_input_readable(read_lin_xfm)

--- a/docs/usage/ciftify_recon_all.md
+++ b/docs/usage/ciftify_recon_all.md
@@ -2,7 +2,8 @@
 
 Converts a freesurfer recon-all output to a working directory
 
-## Usage 
+## Usage
+
 ```
   ciftify_recon_all [options] <Subject>
 
@@ -16,9 +17,16 @@ Options:
                               (overides the SUBJECTS_DIR environment variable)
   --resample-to-T1w32k        Resample the Meshes to 32k Native (T1w) Space
   --surf-reg REGNAME          Registration sphere prefix [default: MSMSulc]
+
   --no-symlinks               Will not create symbolic links to the zz_templates folder
 
   --fs-license FILE           Path to the freesurfer license file
+  --read-non-lin-xfm PATH     EXPERT OPTION, read this FSL format warp to MNI space
+                              instead of generating it from the inputs.
+                              Must be an FSL transform (warp) file.
+  --read-lin-premat PATH      EXPERT OPTION, read this FSL format warp linear (premat)
+                              transform to MNI space instead of generating it.
+                              Must be an an FSL transform (warp) file.
   --MSM-config PATH           EXPERT OPTION. The path to the configuration file to use for
                               MSMSulc mode. By default, the configuration file
                               is ciftify/data/hcp_config/MSMSulcStrainFinalconf
@@ -36,7 +44,8 @@ Options:
 
 
 ```
-## DETAILS 
+## DETAILS
+
 Adapted from the PostFreeSurferPipeline module of the Human Connectome
 Project's minimal proprocessing pipeline. Please cite:
 


### PR DESCRIPTION
ciftify_recon_all can now take in a user given FSL transform
this was tested only by reading in the xfms from another testing run into a new run (we haven't tried to the change the transform in any way)