### PR TITLE
Binder Fix

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN apt-get update && \
 # Set up Bioconda
 RUN conda config --add channels bioconda && \
     conda config --add channels conda-forge && \
-    conda install -c bioconda connectome-workbench
-
+    conda install -c bioconda/label/cf201901 connectome-workbench
+    
 # Get ciftify
 RUN apt-get update && \
     sudo -H pip3 install ciftify datalad

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN conda config --add channels bioconda && \
 
 # Get ciftify
 RUN apt-get update && \
-    apt-get install -y datalad && \
-    pip install ciftify
+    apt-get install -y git-annex && \
+    pip install ciftify datalad
 
 CMD ["jupyter lab"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,14 +4,12 @@ USER root
 
 # Get connectome-workbench
 RUN apt-get update && \
-    apt-get install -y curl gnupg gnupg1 gnupg2 python3-pip 
-    
-RUN apt-get update && \
-    curl -sSL http://neuro.debian.net/lists/xenial.us-ca.full >> /etc/apt/sources.list.d/neurodebian.sources.list && \
-    apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9 && \
-    apt-get update && \
-    apt-get install -y connectome-workbench=1.3.1-1~nd16.04+1
+    apt-get install -y curl gnupg gnupg1 gnupg2 python3-pip
 
+# Set up Bioconda
+RUN conda config --add channels bioconda && \
+    conda config --add channels conda-forge && \
+    conda install -c bioconda connectome-workbench
 
 # Get ciftify
 RUN apt-get update && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,9 +10,10 @@ RUN apt-get update && \
 RUN conda config --add channels bioconda && \
     conda config --add channels conda-forge && \
     conda install -c bioconda/label/cf201901 connectome-workbench
-    
+
 # Get ciftify
 RUN apt-get update && \
-    sudo -H pip3 install ciftify datalad
+    apt-get install -y datalad && \
+    sudo -H pip install ciftify
 
 CMD ["jupyter lab"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,6 @@ RUN conda config --add channels bioconda && \
 # Get ciftify
 RUN apt-get update && \
     apt-get install -y datalad && \
-    sudo -H pip install ciftify
+    pip install ciftify
 
 CMD ["jupyter lab"]


### PR DESCRIPTION
- Uses Bioconda instead of Neurodebian to get Connectome-Workbench
   - This removes the error that occurs where you sometimes fail to receive the key
- Gets ciftify and datalad using conda's pip
- Installs datalad's git-annex requirement