### PR TITLE
[FIX] Update package versions for py3.8

### DIFF
--- a/cifti_requirements.txt
+++ b/cifti_requirements.txt
@@ -4,9 +4,8 @@ pyyaml>=4.2b1
 seaborn>=0.9.0
 pillow==6.2.0
 nilearn>=0.5.0
-numpy==1.15.4
-scipy==1.1.0
-scikit-learn==0.19.1
+numpy>=1.15.4
+scipy>=1.1.0
 matplotlib==2.2.2
 pandas==0.23.4
 pybids>=0.7.0,<0.8.0a0

--- a/cifti_requirements.txt
+++ b/cifti_requirements.txt
@@ -7,6 +7,6 @@ nilearn>=0.5.0
 numpy>=1.15.4
 scipy>=1.1.0
 matplotlib==2.2.2
-pandas==0.23.4
+pandas>=0.23.4
 pybids>=0.7.0,<0.8.0a0
 pytest


### PR DESCRIPTION
Allowing newer versions of scipy, numpy and pandas fixes the build issue + failing tests for python3.8