### PR TITLE
[ENH] Run tests against py3.9

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -38,6 +38,10 @@ jobs:
     <<: *test-template
     docker:
       - image: tigrlab/ciftify_ci:py3.8-latest
+  test-py39:
+    <<: *test-template
+    docker:
+      - image: tigrlab/ciftify_ci:py3.9-latest
   test_and_deploy_docker:
     docker:
       - image: docker:19.03-rc-git
@@ -182,12 +186,17 @@ workflows:
           filters:
             tags:
               only: /.*/
+      - test-py39:
+          filters:
+            tags:
+              only: /.*/
       - test_and_deploy_docker:
           requires:
             - test-py35
             - test-py36
             - test-py37
             - test-py38
+            - test-py39
           filters:
             branches:
               ignore: /.*/
@@ -199,6 +208,7 @@ workflows:
             - test-py36
             - test-py37
             - test-py38
+            - test-py39
           filters:
             branches:
               ignore: /.*/

--- a/.circleci/images/py3.9-20.04-Dockerfile
+++ b/.circleci/images/py3.9-20.04-Dockerfile
@@ -1,0 +1,42 @@
+FROM ubuntu:focal-20200720
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Prepare environment
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends \
+    wget \
+    gnupg \
+    curl \
+    pkg-config \
+    gcc \
+    g++ \
+    libfreetype-dev \
+    libpng-dev \
+    libopenblas-dev \
+    liblapack-dev \
+    libjpeg-dev \
+    gfortran \
+    git \
+    python3.9 \
+    python3.9-venv \
+    python3-setuptools \
+    python3-pip
+
+# Get connectome-workbench
+RUN wget -O- http://neuro.debian.net/lists/focal.us-ca.full >> /etc/apt/sources.list.d/neurodebian.sources.list && \
+        apt-key adv --recv-keys --keyserver hkp://pool.sks-keyservers.net:80 0xA5D32F012649A5A9 && \
+        apt update && \
+        apt install -y connectome-workbench=1.4.2-1build1
+
+# Get bids-validator
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - && \
+        apt-get install -y nodejs && \
+        npm install -g bids-validator
+
+# Ensure python3.9 is the default python3 + update pip
+RUN update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.8 1 && \
+        update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.9 2 && \
+        pip install --upgrade pip
+
+CMD ["/bin/bash"]

--- a/cifti_requirements.txt
+++ b/cifti_requirements.txt
@@ -2,11 +2,11 @@ docopt>=0.6.0
 nibabel>=2.3.3
 pyyaml>=4.2b1
 seaborn>=0.9.0
-pillow==6.2.0
+pillow>=6.2.0
 nilearn>=0.5.0
 numpy>=1.15.4
 scipy>=1.1.0
-matplotlib==2.2.2
+matplotlib>=2.2.2
 pandas>=0.23.4
 pybids>=0.7.0,<0.8.0a0
 pytest


### PR DESCRIPTION
This PR will ensure all tests are also run against python 3.9. Note that it also updates the matplotlib and pillow versions in cifti_requirements.txt. This is because (at least on ubuntu 20.04) installation fails for python 3.9 with the versions that were originally listed.

Also, I wasnt able to replicate the 3.9 issue that that one issue mentioned. I think it might only arise when running the integration tests. I'll take a look at that soon.