### PR TITLE
[FIX] Update ciftify_clean_img.py to catch use cases without confound_signals

### DIFF
--- a/ciftify/bin/ciftify_clean_img.py
+++ b/ciftify/bin/ciftify_clean_img.py
@@ -342,7 +342,7 @@ def clean_image_with_nilearn(input_img, confound_signals, settings):
         clean_output = nilearn.image.clean_img(input_img,
                             detrend=settings.detrend,
                             standardize=settings.standardize,
-                            confounds=confound_signals.values,
+                            confounds=confound_signals.values if confound_signals is not None else None,
                             low_pass=settings.low_pass,
                             high_pass=settings.high_pass,
                             t_r=settings.func.tr)


### PR DESCRIPTION
If confounds are not given then an error occurs. The PR is a minimal patch for this
```console
Traceback (most recent call last):
  File "/home/mrphys/marzwi/.conda/envs/ciftify/bin/ciftify_clean_img", line 8, in <module>
    sys.exit(main())
  File "/home/mrphys/marzwi/.conda/envs/ciftify/lib/python3.9/site-packages/ciftify/bin/ciftify_clean_img.py", line 376, in main
    ret = run_ciftify_clean_img(arguments, tmpdir)
  File "/home/mrphys/marzwi/.conda/envs/ciftify/lib/python3.9/site-packages/ciftify/bin/ciftify_clean_img.py", line 254, in run_ciftify_clean_img
    clean_output = clean_image_with_nilearn(trimmed_nifti, confound_signals, settings)
  File "/home/mrphys/marzwi/.conda/envs/ciftify/lib/python3.9/site-packages/ciftify/bin/ciftify_clean_img.py", line 345, in clean_image_with_nilearn
    confounds=confound_signals.values,
AttributeError: 'NoneType' object has no attribute 'values'
[..]
```