### PR TITLE
[FIX] Update broken website link

### DIFF
--- a/docs/_navbar.md
+++ b/docs/_navbar.md
@@ -1,5 +1,5 @@
 
-- [Quick Start](installation.md)
+- [Quick Start](01_installation.md)
 - demo QC pages
      - [recon_all](https://edickie.github.io/ciftify/demo/qc_recon_all/index.html)
      - [fmri](https://edickie.github.io/ciftify/demo/qc_fmri/index.html)     


### PR DESCRIPTION
The 'Quick Start' link on the top right of the docs site is currently a 404 page because the file name is incorrect.